### PR TITLE
tests: some absolute paths needed to be made relative

### DIFF
--- a/test/dividing-counter.gtkw
+++ b/test/dividing-counter.gtkw
@@ -2,10 +2,10 @@
 [*] GTKWave Analyzer v3.3.109 (w)1999-2020 BSI
 [*] Thu Aug 19 03:44:29 2021
 [*]
-[dumpfile] "/devel/HDL/src/amaranth-library/test_DividingCounterTest_test_basic.vcd"
+[dumpfile] "test_DividingCounterTest_test_basic.vcd"
 [dumpfile_mtime] "Thu Aug 19 03:26:56 2021"
 [dumpfile_size] 3113
-[savefile] "/devel/HDL/src/amaranth-library/test/dividing-counter.gtkw"
+[savefile] "test/dividing-counter.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1

--- a/test/edgetopulse.gtkw
+++ b/test/edgetopulse.gtkw
@@ -5,7 +5,7 @@
 [dumpfile] "test_EdgeToPulseTest_test_basic.vcd"
 [dumpfile_mtime] "Thu Aug 19 02:57:34 2021"
 [dumpfile_size] 960
-[savefile] "/devel/HDL/src/amaranth-library/test/edgetopulse.gtkw"
+[savefile] "test/edgetopulse.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1

--- a/test/serial-led-array.gtkw
+++ b/test/serial-led-array.gtkw
@@ -2,10 +2,10 @@
 [*] GTKWave Analyzer v3.3.111 (w)1999-2020 BSI
 [*] Mon Oct 18 20:41:51 2021
 [*]
-[dumpfile] "/devel/HDL/src/amaranth-library/test_SerialLEDArrayTest_test_spi_interface.vcd"
+[dumpfile] "test_SerialLEDArrayTest_test_spi_interface.vcd"
 [dumpfile_mtime] "Mon Oct 18 20:41:30 2021"
 [dumpfile_size] 338477
-[savefile] "/devel/HDL/src/amaranth-library/test/serial-led-array.gtkw"
+[savefile] "test/serial-led-array.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1

--- a/test/shift-register-in.gtkw
+++ b/test/shift-register-in.gtkw
@@ -5,7 +5,7 @@
 [dumpfile] "test_InputShiftRegisterTest_test_basic.vcd"
 [dumpfile_mtime] "Thu Aug 19 03:53:11 2021"
 [dumpfile_size] 2437
-[savefile] "/devel/HDL/src/amaranth-library/test/shift-register-in.gtkw"
+[savefile] "test/shift-register-in.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1

--- a/test/shift-register-out.gtkw
+++ b/test/shift-register-out.gtkw
@@ -5,7 +5,7 @@
 [dumpfile] "test_OutputShiftRegisterTest_test_basic.vcd"
 [dumpfile_mtime] "Thu Aug 19 04:08:49 2021"
 [dumpfile_size] 1367
-[savefile] "/devel/HDL/src/amaranth-library/test/shift-register-out.gtkw"
+[savefile] "test/shift-register-out.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1

--- a/test/spi-controller.gtkw
+++ b/test/spi-controller.gtkw
@@ -2,10 +2,10 @@
 [*] GTKWave Analyzer v3.3.111 (w)1999-2020 BSI
 [*] Sat Oct 16 06:34:36 2021
 [*]
-[dumpfile] "/devel/HDL/src/amaranth-library/test_SPIControllerInterfaceTest_test_spi_interface.vcd"
+[dumpfile] "test_SPIControllerInterfaceTest_test_spi_interface.vcd"
 [dumpfile_mtime] "Sat Oct 16 06:34:31 2021"
 [dumpfile_size] 9300
-[savefile] "/devel/HDL/src/amaranth-library/test/spi-controller.gtkw"
+[savefile] "test/spi-controller.gtkw"
 [timestart] 0
 [size] 3828 2090
 [pos] -1 -1


### PR DESCRIPTION
Not to be a smartass but some of the manually-pruned /test/*.gtkw files hadn't had the `dumpfile` and `savefile` paths made relative, so this is what I did.

Without this change, I couldn't open the .gtkw files; now I can.

great repo by the way! I'm working on an async-fifo-with-SDRAM-buffer module that I'm getting ready to share.