### PR TITLE
renamed stereo_convolution_mac to new package amlib.dsp.convolution.mac

### DIFF
--- a/amlib/dsp/__init__.py
+++ b/amlib/dsp/__init__.py
@@ -4,6 +4,5 @@ from .fixedpointfirfilter     import FixedPointFIRFilter
 from .filterbank              import Filterbank
 from .fixedpointcicfilter     import FixedPointCICFilter
 from .fixedpointhbfilter      import FixedPointHBFilter
-from .stereo_convolution_mac  import StereoConvolutionMAC, ConvolutionMode
 
-__all__ = [FractionalResampler, FixedPointIIRFilter, FixedPointFIRFilter, Filterbank, FixedPointCICFilter, FixedPointHBFilter, StereoConvolutionMAC, ConvolutionMode]
+__all__ = [FractionalResampler, FixedPointIIRFilter, FixedPointFIRFilter, Filterbank, FixedPointCICFilter, FixedPointHBFilter]

--- a/amlib/dsp/convolution/__init__.py
+++ b/amlib/dsp/convolution/__init__.py
@@ -1,0 +1,4 @@
+from .convolutionmode 	import ConvolutionMode
+from .mac  		import StereoConvolutionMAC
+
+__all__ = [StereoConvolutionMAC, ConvolutionMode]

--- a/amlib/dsp/convolution/convolutionmode.py
+++ b/amlib/dsp/convolution/convolutionmode.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Rouven Broszeit <roubro1991@gmx.de>
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+from enum import Enum
+
+class ConvolutionMode(Enum):
+    CROSSFEED = 1
+    STEREO = 2
+    MONO = 3
+

--- a/amlib/dsp/convolution/mac.py
+++ b/amlib/dsp/convolution/mac.py
@@ -12,10 +12,7 @@ import numpy as np
 import math
 from enum import Enum
 
-class ConvolutionMode(Enum):
-    CROSSFEED = 1
-    STEREO = 2
-    MONO = 3
+from .convolutionmode 	import ConvolutionMode
 
 class StereoConvolutionMAC(Elaboratable):
     """A stereo convolution module which uses the MAC (Multiply-Accumulate) algorithm


### PR DESCRIPTION
Hi @hansfbaier,

did you mean something like this?
Should I change the classname from StereoConvolutionMAC to anything else as well?